### PR TITLE
fix: remove dependency to default in repository.xml

### DIFF
--- a/src/main/import/repository.xml
+++ b/src/main/import/repository.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <content xmlns:j="http://www.jahia.org/jahia/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0">
     <modules jcr:primaryType="jnt:modules">
-        <visibility j:dependencies="default"
-                  j:modulePriority="0"
+        <visibility j:modulePriority="0"
                   j:moduleType="system"
                   j:title="Jahia Visibility"
                   jcr:primaryType="jnt:module">
-
                 <portlets jcr:primaryType="jnt:portletFolder"/>
                 <files jcr:primaryType="jnt:folder"/>
                 <contents jcr:primaryType="jnt:contentFolder"/>
@@ -14,7 +12,6 @@
                     <files jcr:primaryType="jnt:folder"/>
                     <contents jcr:primaryType="jnt:contentFolder"/>
                 </templates>
-
             </visibility>
     </modules>
 </content>


### PR DESCRIPTION
### Description
Remove the dependency to default in the repository.xml file has it's not necessary and causing healthcheck warning

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
