### PR TITLE
fix: switch nodetypes systemId in migration

### DIFF
--- a/src/main/resources/META-INF/patches/groovy/8.2.0-01-removeDefinitions.resolved.groovy
+++ b/src/main/resources/META-INF/patches/groovy/8.2.0-01-removeDefinitions.resolved.groovy
@@ -1,8 +1,11 @@
 import org.jahia.services.content.JCRStoreService
 import org.jahia.osgi.FrameworkService
+import org.jahia.services.content.nodetypes.ExtendedNodeType
+import org.jahia.services.content.nodetypes.NodeTypeRegistry
 import org.osgi.framework.Bundle
 
 def source = "advanced-visibility";
+def target = "visibility";
 
 log.info("Checking if bundle with symbolic name " + source + " needs to be uninstalled");
 Bundle[] bundles = FrameworkService.getBundleContext().getBundles();
@@ -14,7 +17,25 @@ for (Bundle bundle: bundles) {
     }
 }
 
+def toSwitch = ["jnt:timeOfDayCondition", "jnt:dayOfWeekCondition"];
+
+log.info("Check for nodetypes to switch from " + source + " to " + target + " (" + toSwitch.size() + " nodetypes to switch)");
+NodeTypeRegistry nodeTypeRegistry = NodeTypeRegistry.getInstance();
+nodeTypeRegistry.getAllNodeTypes(Arrays.asList(source)).forEach { nodeType ->
+    if (toSwitch.contains(nodeType.getName())) {
+        log.info("Switch nodetype: " + nodeType.getName() + " to " + target);
+        def field = ExtendedNodeType.getDeclaredField("systemId")
+        field.setAccessible(true)
+        try {
+            field.set(nodeType, target);
+        } finally {
+            field.setAccessible(false);
+        }
+        log.info("Successfully switched nodetype: " + nodeType.getName() + " to " + nodeType.getSystemId());
+    }
+}
+
 log.info("Undeploy definitions of " + source);
 JCRStoreService jcrStoreService = JCRStoreService.getInstance();
 jcrStoreService.undeployDefinitions(source);
-log.info("Successfully removed defintions for systemId: " + source);
+log.info("Successfully removed definitions for systemId: " + source);


### PR DESCRIPTION
### Description
Change the systemId of the definitions coming from advanced-visibility to visibility during the migration.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
