### PR TITLE
fix: ensure job correctly stopping/restarting when restarting tomcat

### DIFF
--- a/.chachalog/m0lFMvhc.md
+++ b/.chachalog/m0lFMvhc.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+visibility: patch
+---
+
+Ensure job correctly stopping/restarting when restarting tomcat (#55)

--- a/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJob.java
+++ b/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJob.java
@@ -1,71 +1,21 @@
 package org.jahia.modules.visibility.job;
 
 import org.jahia.services.content.rules.OrphanedActionPurgeJob;
-import org.jahia.services.scheduler.SchedulerService;
-import org.jahia.settings.SettingsBean;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.quartz.CronTrigger;
 import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
-import org.quartz.Trigger;
 
 import java.util.Set;
 
 /**
  * Background task that purges orphaned visibility actions (in case the corresponding node was deleted).
+ * <p>
+ * <b>NB:</b> This job is instantiated directly by Quartz, so OSGi dependency injection is not available here.
+ * Its scheduling (and unscheduling) is handled by the OSGi component {@link VisibilityActionPurgeJobRegistration}.
  *
  * @author Sergiy Shyrkov
  * @author Jerome Blanchard
+ * @see VisibilityActionPurgeJobRegistration
  */
-@Component(immediate = true)
 public class VisibilityActionPurgeJob extends OrphanedActionPurgeJob {
-
-    private static final String JOB_DESCRIPTION = "Cancels (unschedules) and removes orphaned visibility action jobs in case the corresponding node is no longer present";
-    private static final String JOB_GROUP = "Maintenance";
-    private static final String CRON_TRIGGER_NAME = "VisibilityActionPurgeJobTrigger";
-    private static final String CRON_EXPRESSION = "0 5 * * * ?";
-    private static final String JOB_GROUP_NAMES_KEY = "jobGroupNames";
-    private static final Set<String> JOB_GROUP_NAMES = Set.of("ActionJob.startDateVisibilityAction", "ActionJob.endDateVisibilityAction",
-                    "ActionJob.startDayOfWeekVisibilityAction", "ActionJob.endDayOfWeekVisibilityAction",
-                    "ActionJob.startTimeOfDayVisibilityAction", "ActionJob.endTimeOfDayVisibilityAction");
-
-    private SchedulerService schedulerService;
-    private JobDetail jobDetail;
-
-    private static final String JOB_NAME = "visibilityActionPurgeJob";
-
-    @Activate
-    public void start() throws Exception {
-        // Fixed name -> can be retrieved after restart
-        jobDetail = new JobDetail(JOB_NAME, JOB_GROUP, VisibilityActionPurgeJob.class, false, true, false);
-        jobDetail.setDescription(JOB_DESCRIPTION);
-
-        jobDetail.getJobDataMap().put(JOB_GROUP_NAMES_KEY, JOB_GROUP_NAMES);
-        if (SettingsBean.getInstance().isProcessingServer()) {
-            // Delete the old job at startup if exists
-            schedulerService.getScheduler().deleteJob(JOB_NAME, JOB_GROUP);
-            Trigger trigger = new CronTrigger(CRON_TRIGGER_NAME, jobDetail.getGroup(), CRON_EXPRESSION);
-            schedulerService.getScheduler().scheduleJob(jobDetail, trigger);
-        }
-    }
-
-    @Deactivate
-    public void stop() throws Exception {
-        if (schedulerService.getScheduler() == null) {
-            return;
-        }
-        if (SettingsBean.getInstance().isProcessingServer()) {
-            schedulerService.getScheduler().deleteJob(jobDetail.getName(), jobDetail.getGroup());
-        }
-    }
-
-    @Reference
-    public void setSchedulerService(SchedulerService schedulerService) {
-        this.schedulerService = schedulerService;
-    }
 
     @Override
     protected Set<String> getJobGroupNames(JobDataMap data) {
@@ -76,5 +26,4 @@ public class VisibilityActionPurgeJob extends OrphanedActionPurgeJob {
             return super.getJobGroupNames(data);
         }
     }
-
 }

--- a/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJob.java
+++ b/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJob.java
@@ -1,7 +1,6 @@
 package org.jahia.modules.visibility.job;
 
 import org.jahia.services.content.rules.OrphanedActionPurgeJob;
-import org.jahia.services.scheduler.BackgroundJob;
 import org.jahia.services.scheduler.SchedulerService;
 import org.jahia.settings.SettingsBean;
 import org.osgi.service.component.annotations.Activate;
@@ -36,12 +35,18 @@ public class VisibilityActionPurgeJob extends OrphanedActionPurgeJob {
     private SchedulerService schedulerService;
     private JobDetail jobDetail;
 
+    private static final String JOB_NAME = "visibilityActionPurgeJob";
+
     @Activate
     public void start() throws Exception {
-        jobDetail = BackgroundJob.createJahiaJob(JOB_DESCRIPTION, VisibilityActionPurgeJob.class);
-        jobDetail.setGroup(JOB_GROUP);
+        // Fixed name -> can be retrieved after restart
+        jobDetail = new JobDetail(JOB_NAME, JOB_GROUP, VisibilityActionPurgeJob.class, false, true, false);
+        jobDetail.setDescription(JOB_DESCRIPTION);
+
         jobDetail.getJobDataMap().put(JOB_GROUP_NAMES_KEY, JOB_GROUP_NAMES);
-        if (schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
+        if (SettingsBean.getInstance().isProcessingServer()) {
+            // Delete the old job at startup if exists
+            schedulerService.getScheduler().deleteJob(JOB_NAME, JOB_GROUP);
             Trigger trigger = new CronTrigger(CRON_TRIGGER_NAME, jobDetail.getGroup(), CRON_EXPRESSION);
             schedulerService.getScheduler().scheduleJob(jobDetail, trigger);
         }
@@ -49,7 +54,10 @@ public class VisibilityActionPurgeJob extends OrphanedActionPurgeJob {
 
     @Deactivate
     public void stop() throws Exception {
-        if (!schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
+        if (schedulerService.getScheduler() == null) {
+            return;
+        }
+        if (SettingsBean.getInstance().isProcessingServer()) {
             schedulerService.getScheduler().deleteJob(jobDetail.getName(), jobDetail.getGroup());
         }
     }

--- a/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJobRegistration.java
+++ b/src/main/java/org/jahia/modules/visibility/job/VisibilityActionPurgeJobRegistration.java
@@ -1,0 +1,86 @@
+package org.jahia.modules.visibility.job;
+
+import org.jahia.services.scheduler.SchedulerService;
+import org.jahia.settings.SettingsBean;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.quartz.CronTrigger;
+import org.quartz.JobDetail;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.util.Set;
+
+/**
+ * Registration of the {@link VisibilityActionPurgeJob} background job via OSGi.
+ * <p>
+ * <b>NB:</b> This component only handles the registration of the job; the execution itself
+ * (in {@link VisibilityActionPurgeJob}) does not have access to OSGi dependency injection.
+ *
+ * @see VisibilityActionPurgeJob
+ */
+@Component(immediate = true)
+public class VisibilityActionPurgeJobRegistration {
+
+    private static final Logger logger = LoggerFactory.getLogger(VisibilityActionPurgeJobRegistration.class);
+
+    private static final String GROUP_NAME = "Maintenance";
+    private static final String JOB_NAME = "visibilityActionPurgeJob";
+    private static final String JOB_DESCRIPTION = "Cancels (unschedules) and removes orphaned visibility action jobs in case the corresponding node is no longer present";
+    private static final String CRON_TRIGGER_NAME = "VisibilityActionPurgeJobTrigger";
+    private static final String CRON_EXPRESSION = "0 5 * * * ?";
+    private static final String JOB_GROUP_NAMES_KEY = "jobGroupNames";
+    private static final Set<String> JOB_GROUP_NAMES = Set.of("ActionJob.startDateVisibilityAction", "ActionJob.endDateVisibilityAction",
+                    "ActionJob.startDayOfWeekVisibilityAction", "ActionJob.endDayOfWeekVisibilityAction",
+                    "ActionJob.startTimeOfDayVisibilityAction", "ActionJob.endTimeOfDayVisibilityAction");
+
+    private SchedulerService schedulerService;
+    private JobDetail jobDetail;
+
+    @Activate
+    public void start() throws VisibilityJobRegistrationException {
+        // Fixed name -> can be retrieved after restart
+        jobDetail = new JobDetail(JOB_NAME, GROUP_NAME, VisibilityActionPurgeJob.class, false, true, false);
+        jobDetail.setDescription(JOB_DESCRIPTION);
+        jobDetail.getJobDataMap().put(JOB_GROUP_NAMES_KEY, JOB_GROUP_NAMES);
+        if (SettingsBean.getInstance().isProcessingServer()) {
+            try {
+                // Delete the old job at startup if exists
+                schedulerService.getScheduler().deleteJob(JOB_NAME, GROUP_NAME);
+                Trigger trigger = new CronTrigger(CRON_TRIGGER_NAME, jobDetail.getGroup(), CRON_EXPRESSION);
+                schedulerService.getScheduler().scheduleJob(jobDetail, trigger);
+                logger.info("Visibility action purge {} job registered", jobDetail.getName());
+            } catch (SchedulerException | ParseException e) {
+                throw new VisibilityJobRegistrationException("Unable to register the visibility action purge job", e);
+            }
+        }
+    }
+
+    @Deactivate
+    public void stop() throws VisibilityJobRegistrationException {
+        // If Jahia is shutting down, the scheduler is already stopped -> we do nothing.
+        // The job will be cleaned at the next startup. It could be found with the fixed name
+        if (schedulerService.getScheduler() == null) {
+            return;
+        }
+        try {
+            if (!schedulerService.getAllJobs(jobDetail.getGroup()).isEmpty() && SettingsBean.getInstance().isProcessingServer()) {
+                schedulerService.getScheduler().deleteJob(jobDetail.getName(), jobDetail.getGroup());
+                logger.info("Visibility action purge {} job unregistered", jobDetail.getName());
+            }
+        } catch (SchedulerException e) {
+            throw new VisibilityJobRegistrationException("Unable to unregister the visibility action purge job", e);
+        }
+    }
+
+    @Reference
+    public void setSchedulerService(SchedulerService schedulerService) {
+        this.schedulerService = schedulerService;
+    }
+
+}

--- a/src/main/java/org/jahia/modules/visibility/job/VisibilityJobRegistrationException.java
+++ b/src/main/java/org/jahia/modules/visibility/job/VisibilityJobRegistrationException.java
@@ -1,0 +1,14 @@
+package org.jahia.modules.visibility.job;
+
+/**
+ * Thrown when the {@link VisibilityActionPurgeJob} background job cannot be
+ * registered or unregistered from the scheduler.
+ *
+ * @see VisibilityActionPurgeJobRegistration
+ */
+public class VisibilityJobRegistrationException extends Exception {
+
+    public VisibilityJobRegistrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
### Description
This pull request updates the visibility action purge job to improve scheduling reliability and cleanup logic, and refactors it to follow the [Jahia OSGi background-job sample pattern](https://github.com/Jahia/OSGi-modules-samples/tree/main/background-job-samples). The main focus is on ensuring the scheduled job is uniquely identified, old jobs are properly removed on startup, and the OSGi lifecycle is cleanly separated from the Quartz execution.

**Architecture — separation of job and registration:**

* Split the previous all-in-one class into two classes, mirroring the `TestBackgroundJobRegistration` sample:
  * `VisibilityActionPurgeJob` — the Quartz-executed job. It only holds execution logic (`getJobGroupNames`) and is **no longer an OSGi component**, since Quartz instantiates it directly without OSGi dependency injection.
  * `VisibilityActionPurgeJobRegistration` — the OSGi `@Component` that handles scheduling and unscheduling.

**Job scheduling and cleanup improvements:**

* Introduced a fixed job name (`JOB_NAME`) to ensure consistent identification and retrieval after restarts.
* Build the `JobDetail` directly (`new JobDetail(...)`) with the fixed job name and the `Maintenance` group, and set the description explicitly.
* Delete any existing old job with the same name and group at startup before scheduling a new one, preventing duplicate jobs after restarts.
* Improved the `stop` method to check that the scheduler is still available before attempting to delete the job, making shutdown safe when Jahia stops the scheduler before OSGi deactivation.

**Code cleanup:**

* Removed the now-unused import of `BackgroundJob`.
* Replaced the generic `throws Exception` on the `@Activate`/`@Deactivate` methods with a dedicated `VisibilityJobRegistrationException`; scheduler calls are now wrapped in try/catch that rethrows this exception while preserving the original cause (fixes Sonar `java:S112`).

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
